### PR TITLE
Converter failed because it found Text node's between the xf nodes

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -168,6 +168,8 @@ class Styles:
         cellXfsElement = styles.getElementsByTagName("cellXfs")
         if len(cellXfsElement) == 1:
             for cellXfs in cellXfsElement[0].childNodes:
+                if (cellXfs.nodeName != "xf"):
+                    continue
                 numFmtId = int(cellXfs._attrs['numFmtId'].value)
                 self.cellXfs.append(numFmtId)
 


### PR DESCRIPTION
I ran xlsx2csv on an .xlsx file exported from my bank and it crashed because it tried to access _attrs on text nodes. Turns out the parser found a text node consisting of a single newline between each <xf> tag inside the <cellXfs> tag.

I fixed this by simply having the parser verify it's operating on the <xf> tag and ignoring any other tags.

My environment is Python 2.7 on Mac OS X 10.7.
