### PR TITLE
Fix a bug for convert_recursive

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -629,9 +629,9 @@ class Sheet:
 def convert_recursive(path, sheetid, kwargs):
     kwargs['cmd'] = False
     for name in os.listdir(path):
-        fullpath = os.path.join(path, sheetid, name)
+        fullpath = os.path.join(path, name)
         if os.path.isdir(fullpath):
-            convert_recursive(fullpath, kwargs)
+            convert_recursive(fullpath, sheetid, kwargs)
         else:
             if fullpath.lower().endswith(".xlsx"):
                 outfilepath = fullpath[:-4] + 'csv'


### PR DESCRIPTION
To fix following error:

$ xlsx2csv -a . csv
Traceback (most recent call last):
  File "/usr/local/bin/xlsx2csv", line 546, in <module>
    convert_recursive(options.infile, sheetid, kwargs)
  File "/usr/local/bin/xlsx2csv", line 474, in convert_recursive
    convert_recursive(fullpath, kwargs)
TypeError: convert_recursive() takes exactly 3 arguments (2 given)
