### PR TITLE
Format type time is using modulo 1

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -623,7 +623,7 @@ class Sheet:
                                   replace("am/pm", "%p")
                                 self.data = date.strftime(str(dateformat)).strip()
                         elif format_type == 'time': # time
-                            t = int(float(self.data) * 24*60)
+                            t = int(float(self.data)%1 * 24*60)
                             self.data = "%.2i:%.2i" %(t / 60, t % 60)  #str(t / 60) + ":" + ('0' + str(t % 60))[-2:]
                         elif format_type == 'float' and ('E' in self.data or 'e' in self.data):
                             self.data = ("%f" %(float(self.data))).rstrip('0').rstrip('.')


### PR DESCRIPTION
This will make sure to use only the decimal place and not the whole number when converting time formats.

* example
 * before 08:00:00 = 1900-01-01 08:00:00 = **1.33** = 32:00:00
 * after 08:00:00 = 1900-01-01 08:00:00 = **0.33** = 8:00:00

I probably could provide an example xlsx where this occured.