### PR TITLE
Round time to microseconds to prevent one-off errors because of float…

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -620,7 +620,7 @@ class Sheet:
                                   replace("mmmm", "%B").replace("mmm", "%b").replace(":mm", ":%M").replace("m", "%m").replace("%m%m", "%m")
                                 self.data = date.strftime(str(dateformat)).strip()
                         elif format_type == 'time': # time
-                            t = int(float(self.data)%1 * 24*60)
+                            t = int(round((float(self.data)%1) * 24*60*60, 6)) / 60 # round to microseconds
                             self.data = "%.2i:%.2i" %(t / 60, t % 60)  #str(t / 60) + ":" + ('0' + str(t % 60))[-2:]
                         elif format_type == 'float' and ('E' in self.data or 'e' in self.data):
                             self.data = ("%f" %(float(self.data))).rstrip('0').rstrip('.')


### PR DESCRIPTION
… inaccuracies

Excel stores for example the time 12:18 as 0.51249999999999996, which was converted to 12:17. This patch adds rounding to the time formatting to convert the cell to the original 12:18.

Microseconds resolution was chosen for compatibility with the python datetime.timedelta class used elsewhere in the code.
