### PR TITLE
Support my version of excel

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+veersion 0.7.3 (2017-May-20):
+  * Support for "xl/worksheets/worksheet.xml"
+  * Date format "float" leaves value as simple numeric.
+
 version 0.7.2 (2015-Apr-17):
   * bug fixes
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ shutil.copyfile('xlsx2csv.py', 'scripts/xlsx2csv')
 scripts = ["scripts/xlsx2csv"]
 
 name = "xlsx2csv"
-version = "0.7.2"
+version = "0.7.3"
 author = "Dilshod Temirkhdojaev"
 author_email = "tdilshod@gmail.com"
 desc = "xlsx to csv converter"
@@ -44,7 +44,7 @@ data_files=[
 
 setup(
     name='xlsx2csv',
-    version='0.7.2',
+    version='0.7.3',
     description=desc,
     author=author,
     author_email=author_email,

--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -21,7 +21,7 @@
 
 __author__ = "Dilshod Temirkhodjaev <tdilshod@gmail.com>"
 __license__ = "GPL-2+"
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 
 import csv, datetime, zipfile, string, sys, os, re, signal
 import xml.parsers.expat
@@ -241,8 +241,12 @@ class Xlsx2csv:
         try:
             writer = csv.writer(outfile, quoting=csv.QUOTE_MINIMAL, delimiter=self.options['delimiter'], lineterminator=self.options['lineterminator'])
             sheetfile = self._filehandle("xl/worksheets/sheet%i.xml" % sheetid)
+            if not sheetfile:
+                sheetfile = self._filehandle("xl/worksheets/worksheet%i.xml" % sheetid)
             if not sheetfile and sheetid == 1:
                 sheetfile = self._filehandle("xl/worksheets/sheet.xml")
+            if not sheetfile and sheetid == 1:
+                sheetfile = self._filehandle("xl/worksheets/worksheet.xml")
             if not sheetfile:
                 raise SheetNotFoundException("Sheet %s not found" %sheetid)
             try:
@@ -620,6 +624,8 @@ class Sheet:
                     else:
                         format_type = "date"
                 elif re.match("^-?\d+(.\d+)?$", self.data):
+                    format_type = "float"
+                if format_type == 'date' and self.dateformat == 'float' :
                     format_type = "float"
                 if format_type and not format_type in self.ignore_formats :
                     try:


### PR DESCRIPTION
My version of excel uses “xl/worksheets/worksheet.xml”.

Also, I frequently have a use for a date field being in its simple
numer form.  So now you can simply use the date format “float”, which
is interpreted as a special case and leaves the field as a number.