### PR TITLE
Fix handling of an empty "-p" option.

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -958,6 +958,8 @@ if __name__ == "__main__":
 
     if options.sheetdelimiter == '--------':
         pass
+    elif options.sheetdelimiter == '':
+        pass
     elif options.sheetdelimiter == '\\f':
         options.sheetdelimiter = '\f'
     elif options.sheetdelimiter[0] == 'x':


### PR DESCRIPTION
There was a error if you put an empty option "-p".

```
Traceback (most recent call last):
  File "./xlsx2csv.py", line 963, in <module>
    elif options.sheetdelimiter[0] == 'x':
IndexError: string index out of range
```