### PR TITLE
fix loss of data

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -615,6 +615,7 @@ class Sheet:
     def to_csv(self, writer):
         self.writer = writer
         self.parser = xml.parsers.expat.ParserCreate()
+        self.parser.buffer_text = True
         self.parser.CharacterDataHandler = self.handleCharData
         self.parser.StartElementHandler = self.handleStartElement
         self.parser.EndElementHandler = self.handleEndElement


### PR DESCRIPTION
Data loss is caused by the fact that expat can perform multiple call to handleCharData() for the same cell value.
More explanation can be found here : https://docs.python.org/3/library/pyexpat.html#xml.parsers.expat.xmlparser.buffer_text
This could lead to more memory consumption for very big cell but it should not be the common case.
Else, the code should be rewritten to handle multiple call of handleCharData() for the same cell value.
This is supposed to fix issue #142 "Digits lost in conversion".