### PR TITLE
Update copyright year

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -2,7 +2,7 @@
 #
 #   Copyright information
 #
-#	Copyright (C) 2010-2012 Dilshod Temirkhodjaev <tdilshod@gmail.com>
+#	Copyright (C) 2010-2018 Dilshod Temirkhodjaev <tdilshod@gmail.com>
 #
 #   License
 #


### PR DESCRIPTION
Note that because there have been changes in every year from 2010 to
now, continuing to express the copyright year as a range is fine.