### PR TITLE
Use integer divison for format_type time

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -687,7 +687,7 @@ class Sheet:
                                 self.data = date.strftime(str(dateformat)).strip()
                         elif format_type == 'time': # time
                             t = int(round((float(self.data) % 1) * 24*60*60, 6)) # it should be in seconds
-                            d = datetime.time((t / 3600) % 24, (t / 60) % 60, t % 60)
+                            d = datetime.time((t // 3600) % 24, (t // 60) % 60, t % 60)
                             self.data = d.strftime(self.timeformat)
                         elif format_type == 'float' and ('E' in self.data or 'e' in self.data):
                             self.data = str(self.floatformat or '%f') % float(self.data)


### PR DESCRIPTION
The datetime.time function only accepts integers as its arguments.
On python >= 3 the / operator returns a float data type.
Using the // operator ensures a floor division is used and an int is returned.

(See also [PEP 238 -- Changing the Division Operator](https://www.python.org/dev/peps/pep-0238/))

Fixes the following exception:
```
  File "C:\Python34\lib\site-packages\xlsx2csv.py", line 197, in convert
    self._convert(sheetid, outfile)
  File "C:\Python34\lib\site-packages\xlsx2csv.py", line 277, in _convert
    sheet.to_csv(writer)
  File "C:\Python34\lib\site-packages\xlsx2csv.py", line 625, in to_csv
    self.parser.ParseFile(self.filehandle)
  File "..\Modules\pyexpat.c", line 273, in CharacterData
  File "C:\Python34\lib\site-packages\xlsx2csv.py", line 687, in handleCharData
    d = datetime.time((t / 3600) % 24, (t / 60) % 60, t % 60)
TypeError: integer argument expected, got float
```