### PR TITLE
sheet_path cannot be assumed to exist, need to check with _filehandle

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -289,15 +289,26 @@ class Xlsx2csv:
                     if not (sheet_path.startswith("/xl/") or sheet_path.startswith("xl/")):
                         sheet_path = "/xl/" + sheet_path
 
+            sheet_file = None
             if sheet_path is None:
                 sheet_path = "/xl/worksheets/sheet%i.xml" % sheet_index
+                sheet_file = self._filehandle(sheet_path)
+                if sheet_file is None:
+                    sheet_path = None
             if sheet_path is None:
                 sheet_path = "/xl/worksheets/worksheet%i.xml" % sheet_index
+                sheet_file = self._filehandle(sheet_path)
+                if sheet_file is None:
+                    sheet_path = None
             if sheet_path is None and sheet_index == 1:
                 sheet_path = self.content_types.types["worksheet"]
-            if sheet_path is None:
+                sheet_file = self._filehandle(sheet_path)
+                if sheet_file is None:
+                    sheet_path = None
+            if sheet_file is None and sheet_path is not None:
+                sheet_file = self._filehandle(sheet_path)
+            if sheet_file is None:
                 raise SheetNotFoundException("Sheet %i not found" % sheet_index)
-            sheet_file = self._filehandle(sheet_path)
             sheet = Sheet(self.workbook, self.shared_strings, self.styles, sheet_file)
             try:
                 relationships_path = os.path.join(os.path.dirname(sheet_path),


### PR DESCRIPTION
https://github.com/dilshod/xlsx2csv/commit/8d2ba4e4a618db2df7b88fc8c1f8ddc6b2c0b146#diff-fb3c758f7f6d950554579389ff70a33eL260 forgot to check `sheet_path` exists before trying the other naming options, as a result anything not named `sheet%i` fails:
```
$ unzip -t somefile.xlsx
Archive:  somefile.xlsx
    testing: _rels/workbook.xml.rels  OK
    testing: _rels/.rels              OK
    testing: xl/worksheets/data.xml   OK   <------------
    testing: stylesheet.xml           OK
    testing: [Content_Types].xml      OK
    testing: workbook.xml             OK

alex@aineko:~/src/xlsx2csv$ ./xlsx2csv/xlsx2csv.py -a somefile.xlsx 
-------- 1 - Data
Traceback (most recent call last):
  File "./xlsx2csv/xlsx2csv.py", line 1135, in <module>
    xlsx2csv.convert(outfile, sheetid)
  File "./xlsx2csv/xlsx2csv.py", line 258, in convert
    self._convert(s['index'], of)
  File "./xlsx2csv/xlsx2csv.py", line 322, in _convert
    sheet_file.close()
AttributeError: 'NoneType' object has no attribute 'close'
```

This patch puts back in the calls to `_filehandler` which were stripped when 8d2ba4e4a618db2df7b88fc8c1f8ddc6b2c0b146 was merged.