### PR TITLE
Quotes in formatCode case handled, standard format 22 changed to m/d/yy hh:mm

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -106,7 +106,7 @@ STANDARD_FORMATS = {
     19: 'h:mm:ss am/pm',
     20: 'h:mm',
     21: 'h:mm:ss',
-    22: 'm/d/yy h:mm',
+    22: 'm/d/yy hh:mm',
     37: '#,##0 ;(#,##0)',
     38: '#,##0 ;[red](#,##0)',
     39: '#,##0.00;(#,##0.00)',
@@ -513,7 +513,7 @@ class Styles:
             for numFmt in numFmtsElement[0].childNodes:
                 if numFmt.nodeType == minidom.Node.ELEMENT_NODE:
                     numFmtId = int(numFmt._attrs['numFmtId'].value)
-                    formatCode = numFmt._attrs['formatCode'].value.lower().replace('\\', '')
+                    formatCode = numFmt._attrs['formatCode'].value.lower().replace('\\', '').replace('"', '')
                     self.numFmts[numFmtId] = formatCode
 
         if styles.namespaceURI:

--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -513,7 +513,10 @@ class Styles:
             for numFmt in numFmtsElement[0].childNodes:
                 if numFmt.nodeType == minidom.Node.ELEMENT_NODE:
                     numFmtId = int(numFmt._attrs['numFmtId'].value)
-                    formatCode = numFmt._attrs['formatCode'].value.lower().replace('\\', '').replace('"', '')
+                    formatCode = numFmt._attrs['formatCode'].value.lower()
+                    bad_chars = ['\\', '"']
+                    for bad_char in bad_chars:
+                        formatCode = formatCode.replace(bad_char, '')
                     self.numFmts[numFmtId] = formatCode
 
         if styles.namespaceURI:


### PR DESCRIPTION
**Problem 1:** While converting date of following excel file format was detected as **mmm d", "yyyy** and converted to **March 14", "2019**

![excel_date_format_with_quote](https://user-images.githubusercontent.com/11443110/66737388-75745800-ee89-11e9-87dd-559211eb65e4.png)

formatCode in xml header was `<numFmt numFmtId="165" formatCode="MMMM\
 D&quot;, &quot;YYYY"/>`

Since date does not generally contain quotes hence removed all quotes in formatCode extracted.

**Problem 2:** Date 09/01/19 13:00 was detected as **dd/mm/yy h:mm** and converted to CSV as 09/01/19 01:00 from standard format 22
Since date without am/pm is generally in 24 hr format hence changed it to 
`22: 'm/d/yy hh:mm'`

