### PR TITLE
Issue #207: Fix numFmtID when chk_exists returns None

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -528,7 +528,7 @@ class Styles:
                 if cellXfs._attrs and 'numFmtId' in cellXfs._attrs:
                     numFmtId = int(cellXfs._attrs['numFmtId'].value)
                     if self.chk_exists(numFmtId) == None:
-                        numFmtId = int(cellXfs._attrs['applyNumberFormat'].value)
+                        numFmtId = int(cellXfs._attrs['applyNumberFormat'].value == 'true')
                     self.cellXfs.append(numFmtId)
                 else:
                     self.cellXfs.append(None)


### PR DESCRIPTION
cellXfs._attrs['applyNumberFormat'].value returns a literal 'true' or 'false' which throws an error when int() is called. Switch numFmtId = int(cellXfs._attrs['applyNumberFormat'].value) to numFmtId = int(cellXfs._attrs['applyNumberFormat'].value == 'true')