### PR TITLE
Handle missing input file explicitly

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -1190,6 +1190,8 @@ if __name__ == "__main__":
     try:
         if os.path.isdir(options.infile):
             convert_recursive(options.infile, sheetid, outfile, kwargs)
+        elif not os.path.exists(options.infile):
+            raise InvalidXlsxFileException("Input file not found!")
         else:
             xlsx2csv = Xlsx2csv(options.infile, **kwargs)
             if options.sheetname:


### PR DESCRIPTION
This PR introduces a check for and raises an exception when the user passes a non-existing file as input. Without this PR, when the user passes a non-existing file this error is raised:

> Exception AttributeError: "Xlsx2csv instance has no attribute 'ziphandle'" in <bound method Xlsx2csv.__del__ of <__main__.Xlsx2csv instance at 0x02BD9940>> ignored

This is the same exception raised when a non-XLSX file is passed, making debugging a little confusing. This PR makes the situation clear.