### PR TITLE
Add flag to suppress invalid formulas

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -192,6 +192,7 @@ class Xlsx2csv:
         options.setdefault("ignore_formats", [''])
         options.setdefault("lineterminator", "\n")
         options.setdefault("outputencoding", "utf-8")
+        options.setdefault("ignore_invalid_char_data", False)
 
         self.options = options
         try:
@@ -867,8 +868,14 @@ class Sheet:
                         # unsupported float formatting
                         self.data = ("%f" % (float(self.data))).rstrip('0').rstrip('.')
 
-                except (ValueError, OverflowError):  # this catch must be removed, it's hiding potential problems
-                    raise XlsxValueError("Error: potential invalid date format.")
+                except (ValueError, OverflowError):
+                    if self.options['ignore_invalid_char_data']:
+                      # NOTE (khsu): If invalid character data or excel formulas
+                      # are encountered, we set the data to None to avoid reading
+                      # the data from this cell.
+                      self.data = None
+                    else:
+                      raise XlsxValueError("Error: potential invalid date format.")
 
     def handleStartElement(self, name, attrs):
         has_namespace = name.find(":") > 0


### PR DESCRIPTION
When excel files have invalid formulas/data, this can cause `xlsx2csv` to produce an error like the following below (traceback truncated to only include the `xlsx2csv` errors):

```python
Traceback (most recent call last):
  File "/shared/ceph/homes/khsu/data_warehouse/integration/penv/lib/python3.7/site-packages/xlsx2csv.py", line 860, in handleCharData
    self.data = ("%f" % (float(self.data))).rstrip('0').rstrip('.')
ValueError: could not convert string to float: '#N/A'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
...
  File "/shared/ceph/homes/khsu/data_warehouse/tools/src/preproc/read.py", line 155, in read_excel
    xlsx2csv.Xlsx2csv(infile).convert(outfile, sheetid=sheet_id)
  File "/shared/ceph/homes/khsu/data_warehouse/integration/penv/lib/python3.7/site-packages/xlsx2csv.py", line 235, in convert
    self._convert(sheetid, outfile)
  File "/shared/ceph/homes/khsu/data_warehouse/integration/penv/lib/python3.7/site-packages/xlsx2csv.py", line 353, in _convert
    sheet.to_csv(writer)
  File "/shared/ceph/homes/khsu/data_warehouse/integration/penv/lib/python3.7/site-packages/xlsx2csv.py", line 782, in to_csv
    self.parser.ParseFile(self.filehandle)
  File "/home/ebyrne/rpmbuild/BUILD/Python-3.7.4/Modules/pyexpat.c", line 282, in CharacterData
  File "/shared/ceph/homes/khsu/data_warehouse/integration/penv/lib/python3.7/site-packages/xlsx2csv.py", line 874, in handleCharData
    raise XlsxValueError("Error: potential invalid date format.")
xlsx2csv.XlsxValueError: Error: potential invalid date format.
```

This occurs with invalid formulas like `#N/A` and `#VALUE!`. Because `xlsx2csv` doesn't know how to handle these, this breaks the conversion. This PR aims to fix these issues by removing the faulty data instead of trying to force a conversion onto it when an invalid formula is encountered.