### PR TITLE
hyperlinks crash string bytes

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -349,7 +349,7 @@ class Xlsx2csv:
                 if self.options['escape_strings'] and sheet.filedata:
                     sheet.filedata = re.sub(r"(<v>[^<>]+)&#10;([^<>]+</v>)", r"\1\\n\2",
                                             re.sub(r"(<v>[^<>]+)&#9;([^<>]+</v>)", r"\1\\t\2",
-                                                   re.sub(r"(<v>[^<>]+)&#13;([^<>]+</v>)", r"\1\\r\2", sheet.filedata)))
+                                                   re.sub(r"(<v>[^<>]+)&#13;([^<>]+</v>)", r"\1\\r\2", sheet.filedata.decode())))
                 sheet.to_csv(writer)
             finally:
                 sheet_file.close()


### PR DESCRIPTION
Thank you for the useful utility.

This change prevents the following crash that occurs when invoked with the `--hyperlinks` option:

```
Traceback (most recent call last):
  File "./xlsx2csv.py", line 1214, in <module>
    main()
  File "./xlsx2csv.py", line 1207, in main
    xlsx2csv.convert(outfile, sheetid)
  File "./xlsx2csv.py", line 234, in convert
    self._convert(sheetid, outfile)
  File "./xlsx2csv.py", line 352, in _convert
    re.sub(r"(<v>[^<>]+)&#13;([^<>]+</v>)", r"\1\\r\2", sheet.filedata)))
  File "/usr/lib64/python3.10/re.py", line 209, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: cannot use a string pattern on a bytes-like object
```