### PR TITLE
Replace deprecated BadZipfile with BadZipFile

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -198,7 +198,7 @@ class Xlsx2csv:
         self.options = options
         try:
             self.ziphandle = zipfile.ZipFile(xlsxfile)
-        except (zipfile.BadZipfile, IOError):
+        except (zipfile.BadZipFile, IOError):
             raise InvalidXlsxFileException("Invalid xlsx file: " + str(xlsxfile))
 
         self.py3 = sys.version_info[0] == 3
@@ -1038,7 +1038,7 @@ def convert_recursive(path, sheetid, outfile, kwargs):
             print("Converting %s to %s" % (fullpath, outfilepath))
             try:
                 Xlsx2csv(fullpath, **kwargs).convert(outfilepath, sheetid)
-            except zipfile.BadZipfile:
+            except zipfile.BadZipFile:
                 raise InvalidXlsxFileException("File %s is not a zip file" % fullpath)
 
 


### PR DESCRIPTION
`BadZipfile` (with a small `f`) has been deprecated since Python 3.2, use `BadZipFile` (big `F`) instead, added in 3.2.

* https://docs.python.org/3/library/zipfile.html#zipfile.BadZipfile
* https://github.com/python/cpython/issues/86437
