### PR TITLE
stdin: fix false no file test and add tests for stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pip install xlsx2csv
 ```
 **positional arguments:**
 ```
-  xlsxfile              xlsx file path
+  xlsxfile              xlsx file path, use '-' to read from STDIN
   outfile               output csv file path, or directory if -s 0 is specified
 ```
 **optional arguments:**

--- a/man/xlsx2csv.1.pod
+++ b/man/xlsx2csv.1.pod
@@ -50,6 +50,10 @@ xlsx2csv - Convert xlsx xml files to csv format
 
 The conversion uses Expat SAX parser for xml processing.
 
+=head1 STDIN
+
+Use "-" for INFILE to read from the STDIN.
+
 =head1 OPTIONS
 
 =over 4

--- a/test/run
+++ b/test/run
@@ -20,15 +20,16 @@ def compare(case, arguments=[]):
         ext = "xlsx"
         if os.path.exists("test/%s.xlsm" % case):
             ext = "xlsm"
-
+        
         if os.name == 'posix':# in case of Linux
-            left = subprocess.check_output(["python%s" %pyver, "./xlsx2csv.py"] + arguments + ["test/%s.%s" %(case, ext)]).decode('utf-8').replace('\r','')
+            command = ["python%s" %pyver]
         elif os.name == 'nt':# in case of Windows
             # Use py.exe http://blog.python.org/2011/07/python-launcher-for-windows_11.html on Windows
-            left = subprocess.check_output(["py", "-%s" %pyver, "./xlsx2csv.py"] + arguments + ["test/%s.%s" %(case, ext)]).decode('utf-8').replace('\r','')
+            command = ["py", "-%s" %pyver] 
         else:
             print("os.name is unexpected: "+os.name)
             sys.exit(1)
+        left = subprocess.check_output(command + ["./xlsx2csv.py"] + arguments + ["test/%s.%s" %(case, ext)]).decode('utf-8').replace('\r','')
 
         f = open("test/%s.csv" %case, "r", encoding="utf-8", newline="")
         right = f.read().replace('\r','')
@@ -41,8 +42,27 @@ def compare(case, arguments=[]):
             failed = True
         else:
             print("OK: %s %s" %(case, pyver))
+
+        # test STDIN, only works for python3
+        if pyver == "2":
+            continue
+
+        xfile = open("test/%s.%s" %(case,ext), "rb")
+        stdin = xfile.read()
+        xfile.close()
+
+        pipe = subprocess.run(command + ["./xlsx2csv.py"] + arguments + ["-"], input = stdin, capture_output = True)
+        stdinleft = pipe.stdout.decode("utf-8").replace('\r','').replace('\r','')
+
+        if stdinleft != right:
+            print("FAILED (STDIN): %s %s" %(case, pyver))
+            failed = True
+        else:
+            print("OK (STDIN): %s %s" %(case, pyver))
+
     if failed:
         sys.exit(1)
+
 
 compare("datetime", ["--dateformat=%Y-%m-%d %H:%M:%S"])
 compare("empty_row")

--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -1067,7 +1067,7 @@ def main():
 
     if "ArgumentParser" in globals():
         parser = ArgumentParser(description="xlsx to csv converter")
-        parser.add_argument('infile', metavar='xlsxfile', help="xlsx file path")
+        parser.add_argument('infile', metavar='xlsxfile', help="xlsx file path, use '-' to read from STDIN")
         parser.add_argument('outfile', metavar='outfile', nargs='?', help="output csv file path")
         parser.add_argument('-v', '--version', action='version', version=__version__)
         nargs_plus = "+"
@@ -1216,7 +1216,7 @@ def main():
     try:
         if os.path.isdir(options.infile):
             convert_recursive(options.infile, sheetid, outfile, kwargs)
-        elif not os.path.exists(options.infile):
+        elif not os.path.exists(options.infile) and options.infile != "-":
             raise InvalidXlsxFileException("Input file not found!")
         else:
             xlsx2csv = Xlsx2csv(options.infile, **kwargs)


### PR DESCRIPTION
Commit 5a14efcef broke input from stdin, with the check added for actually existing files. Add an exception when the file input is "-" so reading from stdin works again. The original commit that introduced this feature did not include documentation. Add documentation to "--help", manpages and the README. Add testing for reading from stdin with python3 so future commits will not break the feature unintentionally.

Fixes: #270