### PR TITLE
Added more information to date format error

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ pip install xlsx2csv
                         sheet name to convert
   -d DELIMITER, --delimiter DELIMITER
                         delimiter - columns delimiter in csv, 'tab' or 'x09'
-                        for a tab (default: comma ',')
+                        for a tab,
+                        'fs' for fileseparator (ASCII 28) 
+                        (default: comma ',')
   -l LINETERMINATOR, --lineterminator LINETERMINATOR
                         line terminator - lines terminator in csv, '\n' '\r\n'
                         or '\r' (default: os.linesep)

--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -895,7 +895,7 @@ class Sheet:
                             self.data = ("%f" % data).rstrip('0').rstrip('.')
 
                 except (ValueError, OverflowError):  # this catch must be removed, it's hiding potential problems
-                    raise XlsxValueError("Error: potential invalid date format.")
+                    raise XlsxValueError("Error: potential invalid date format at row: " + self.rowNum + ", column: " + self.colNum + ", value: " + self.data)
 
     def handleStartElement(self, name, attrs):
         has_namespace = name.find(":") > 0
@@ -1087,7 +1087,7 @@ def main():
     parser.add_argument("-c", "--outputencoding", dest="outputencoding", default="utf-8", action="store",
                         help="encoding of output csv ** Python 3 only ** (default: utf-8)")
     parser.add_argument("-d", "--delimiter", dest="delimiter", default=",",
-                        help="delimiter - columns delimiter in csv, 'tab' or 'x09' for a tab (default: comma ',')")
+                        help="delimiter - columns delimiter in csv, 'tab' or 'x09' for a tab, 'fs' for File Separator (ASCII 28)  (default: comma ',')")
     parser.add_argument("--hyperlinks", "--hyperlinks", dest="hyperlinks", action="store_true", default=False,
                         help="include hyperlinks")
     parser.add_argument("-e", "--escape", dest='escape_strings', default=False, action="store_true",


### PR DESCRIPTION
I modified output string of error message to include row, column and value causing date format error so it's easier to find a problem with source file.

Output looks like this:
`Error: potential invalid date format at row: 1672, column: BW, value: 24568465 `

I also updated readme and in script description of delimiter parameter to include FS separator from my previous pull request #267 