### PR TITLE
enhancement-skipemptycolumns

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -653,7 +653,6 @@ class Sheet:
         self.cellId = None
         self.s_attr = None
         self.data = None
-        self.max_columns = -1
 
         self.dateformat = None
         self.timeformat = "%H:%M"  # default time format
@@ -995,13 +994,9 @@ class Sheet:
                         d.append("")
 
                     if self.skip_trailing_columns:
-                        if self.max_columns < 0:
-                            self.max_columns = len(d)
-                            while len(d) > 0 and d[-1] == "":
-                                d = d[0:-1]
-                                self.max_columns = self.max_columns - 1
-                        elif self.max_columns > 0:
-                            d = d[0:self.max_columns]
+                        while len(d) > 0 and d[-1] == "":
+                            d.pop()
+
                     self.writer.writerow(d)
 
             self.in_row = False


### PR DESCRIPTION
skip_trailing_columns: don't assume the first line to be the longest and use pop to speed the computation, as it's now done for each line of the sheet