### PR TITLE
Fix potential `SyntaxError` when >= Python 3.12 (regex)

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -836,7 +836,7 @@ class Sheet:
                 if format_str in FORMATS:
                     format_type = FORMATS[format_str]
                 elif re.match(r"^\d+(\.\d+)?$", self.data) and re.match(".*[hsmdyY]", format_str) and not re.match(
-                        '.*\[.*[dmhys].*\]', format_str):
+                        r".*\[.*[dmhys].*\]", format_str):
                     # it must be date format
                     if float(self.data) < 1:
                         format_type = "time"


### PR DESCRIPTION
One of the regexes hadn't been set as a raw string; fixing that can avoid the following error on Python 3.12:
```python
E       and not re.match(".*\[.*[dmhys].*\]", format_str)
E                        ^^^^^^^^^^^^^^^^^^^
E   SyntaxError: invalid escape sequence '\['
``` 