### PR TITLE
Fix deprecation warning in `re.sub` for Python 3.13

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -878,7 +878,7 @@ class Sheet:
                         else:
                             # ignore ";@", don't know what does it mean right now
                             # ignore "[$-409], [$-f409], [$-16001]" and similar format codes
-                            dateformat = re.sub(r"\[\$\-[A-z0-9]*\]", "", format_str, 1) \
+                            dateformat = re.sub(r"\[\$\-[A-z0-9]*\]", "", format_str, count=1) \
                                 .replace(";@", "").replace("yyyy", "%Y").replace("yy", "%y") \
                                 .replace("hh:mm", "%H:%M").replace("h", "%I").replace("%H%H", "%H") \
                                 .replace("ss", "%S").replace("dddd", "d").replace("dd", "d").replace("d", "%d") \


### PR DESCRIPTION
I know xlsx2csv doesn't officially support Python 3.13, but there is no reason it couldn't!

We support `xlsx2csv` as an engine in Polars and we'd like to support Python 3.13. Currently, using `xlsx2csv` works fine but it throws a deprecation warning: `re.sub` now expects the `count` parameter as a keyword argument rather than positional.

I checked earlier versions of Python (3.4 onwards and 2.7) and it seems that in all cases, the parameter is named `count`, so using a keyword argument here shouldn't break anything.

It was a simple fix, hopefully this can be a tiny step towards Python 3.13 support!