### PR TITLE
fix typo: xslx->xlsx

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -156,7 +156,7 @@ class XlsxValueError(XlsxException):
 
 class Xlsx2csv:
     """
-     Usage: Xlsx2csv("test.xslx", **params).convert("test.csv", sheetid=1)
+     Usage: Xlsx2csv("test.xlsx", **params).convert("test.csv", sheetid=1)
      Input:
        xlsxfile - path to file or filehandle
      options:


### PR DESCRIPTION
It seems that the repository description needs fixing.
<img width="356" alt="スクリーンショット 2025-02-25 19 25 13" src="https://github.com/user-attachments/assets/ef014a21-bce7-41d3-9dc9-38eb8f489b06" />
