### PR TITLE
Fixes to parse PowerBI xlsx export files

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -1009,8 +1009,12 @@ class Sheet:
             self.in_cell = True
         elif self.in_cell and ((name == 'v' or name == 't') or (has_namespace and name.endswith(':v'))):
             self.in_cell_value = True
-        elif self.in_sheet and (name == 'row' or (has_namespace and name.endswith(':row'))) and ('r' in attrs) and not (self.skip_hidden_rows and 'hidden' in attrs and attrs['hidden'] == '1'):
-            self.rowNum = attrs['r']
+        elif self.in_sheet and (name == 'row' or (has_namespace and name.endswith(':row'))) and not (self.skip_hidden_rows and 'hidden' in attrs and attrs['hidden'] == '1'):
+            self.rowIndex += 1
+            if 'r' in attrs:
+                self.rowNum = attrs['r']
+            else:
+                self.rowNum = str(self.rowIndex)
             self.in_row = True
             self.colIndex = 0
             self.colNum = ""
@@ -1021,6 +1025,7 @@ class Sheet:
 
         elif name == 'sheetData' or (has_namespace and name.endswith(':sheetData')):
             self.in_sheet = True
+            self.rowIndex = 0
         elif name == 'dimension':
             rng = attrs.get("ref").split(":")
             if len(rng) > 1:

--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -1007,7 +1007,7 @@ class Sheet:
                 self.colIndex += 1
             self.data = ""
             self.in_cell = True
-        elif self.in_cell and ((name == 'v' or name == 't') or (has_namespace and name.endswith(':v'))):
+        elif self.in_cell and ((name == 'v' or name == 't') or (has_namespace and (name.endswith(':v') or name.endswith(':t')))):
             self.in_cell_value = True
         elif self.in_sheet and (name == 'row' or (has_namespace and name.endswith(':row'))) and not (self.skip_hidden_rows and 'hidden' in attrs and attrs['hidden'] == '1'):
             self.rowIndex += 1
@@ -1040,7 +1040,7 @@ class Sheet:
 
     def handleEndElement(self, name):
         has_namespace = name.find(":") > 0
-        if self.in_cell and ((name == 'v' or name == 't') or (has_namespace and name.endswith(':v'))):
+        if self.in_cell and ((name == 'v' or name == 't') or (has_namespace and (name.endswith(':v') or name.endswith(':t')))):
             self.in_cell_value = False
         elif self.in_cell and (name == 'c' or (has_namespace and name.endswith(':c'))):
             t = 0


### PR DESCRIPTION
Fixes https://github.com/dilshod/xlsx2csv/issues/296
With exported xlsx files from PowerBI as input xlsx2csv gave no output. After opening and saving such a file with Excel 365, xlsx2csv gave expected output. In the original export file there is no `xl/sharedStrings.xml` and `xl/worksheets/sheet1.xml` contains inline strings like this:
```
  <x:sheetData>
    <x:row>
      <x:c s="2" t="inlineStr">
        <x:is>
          <x:t>Column1</x:t>
        </x:is>
      </x:c>
      <x:c s="2" t="inlineStr">
        <x:is>
          <x:t>Column2</x:t>
        </x:is>
      </x:c>
```
With these commits xlsx2csv on the original file gave the exact same output (shasum verified) as on the Excel-saved version of it.