### PR TITLE
Fix: safe access to applyNumberFormat attribute

### DIFF
--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -610,7 +610,7 @@ class Styles:
                 if cellXfs._attrs and 'numFmtId' in cellXfs._attrs:
                     numFmtId = int(cellXfs._attrs['numFmtId'].value)
                     if self.chk_exists(numFmtId) == None:
-                        numFmtId = int(cellXfs._attrs['applyNumberFormat'].value)
+                        numFmtId = int(cellXfs._attrs.get('applyNumberFormat', 0))
                     self.cellXfs.append(numFmtId)
                 else:
                     self.cellXfs.append(None)


### PR DESCRIPTION
 Fix KeyError exception when directly accessing applyNumberFormat attribute at line 613 of xlsx2csv.py.

 Problem: When applyNumberFormat attribute does not exist in cellXfs._attrs, using cellXfs._attrs['applyNumberFormat'] directly raises a KeyError.

 Solution: Use cellXfs._attrs.get('applyNumberFormat', 0) for safe access, returning default value 0 when the attribute is missing.

 Changes: xlsx2csv.py:613 — changed direct access to .get() safe access